### PR TITLE
Ignore .tmp directory

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+/.tmp


### PR DESCRIPTION
`grant uglify` task creates `.tmp/bookmarklet.js`, but this isn't necessary under version control.
