### PR TITLE
negate_iife option adds ! to output, that breaks bookmarklet in Firefox ...

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -17,7 +17,9 @@ gulp.task('scripts', function () {
   gulp.src('app/{,*/}*.js')
     .pipe(gulpJshint())
     .pipe(gulpJshint.reporter(jshintStylish))
-    .pipe(gulpUglify())
+    .pipe(gulpUglify({
+      compress: { 'negate_iife': false }
+    }))
     .pipe(gulpConcat('bookmarklet.js'))
     .pipe(map(function (file, cb) {
       file.contents = buffer.Buffer.concat([header, file.contents]);


### PR DESCRIPTION
By default, in this generator Gulp produces the bookmarklet like:

``` javascript
javascript:!function(){ /* ... */}();
```

It breaks bookmarklet on Firefox, because after clicking on it — you are redirected to blank page with 'false' text on it.

So, after my fix

``` javascript
gulpUglify({
    compress: { 'negate_iife': false }
})
```

Gulp will produce the output that is understood not only by Chrome, but by Firefox too:

``` javascript
javascript:(function(){})();
```

Regards,
Yaroslav.
