### PR TITLE
Update to Gulp Version 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ You can find the resulting bookmarklet in `dist/bookmarklet.js`.
 
 ## Changelog
 
+#### 0.2.2 (2014-10-04)
+
+- Update to Gulp Version 3.8
+- Removed [`gulp.run`](https://github.com/gulpjs/gulp/issues/199)
+- Replaces [gulp-clean](https://github.com/peter-vilja/gulp-clean) with [gulp-rimraf](https://github.com/robrich/gulp-rimraf)
+
 ### 0.2.0 (2014-01-03)
 
 - Replaced grunt with gulp.

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -3,10 +3,10 @@
   "version": "0.0.0",
   "dependencies": {},
   "devDependencies": {
-    "gulp": "~3.2.2",
-    "gulp-clean": "~0.1.3",
+    "gulp": "~3.8",
     "gulp-concat": "~2.1.6",
     "gulp-jshint": "~1.3.4",
+    "gulp-rimraf": "^0.1.1",
     "gulp-uglify": "~0.1.0",
     "gulp-util": "~2.2.5",
     "jshint-stylish": "~0.1.4",

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -1,43 +1,36 @@
 // Generated on <%= (new Date).toISOString().split('T')[0] %> using <%= pkg.name %> <%= pkg.version %>
-
 'use strict';
 
 var buffer = require('buffer');
 var gulp = require('gulp');
-var gulpClean = require('gulp-clean');
+var rimraf = require('gulp-rimraf');
 var gulpConcat = require('gulp-concat');
 var gulpJshint = require('gulp-jshint');
 var gulpUglify = require('gulp-uglify');
 var jshintStylish = require('jshint-stylish');
 var map = require('map-stream');
 
-gulp.task('scripts', function () {
+gulp.task('scripts', function() {
   var header = new Buffer('// Copy this to your URL bar:\njavascript:');
 
   gulp.src('app/{,*/}*.js')
     .pipe(gulpJshint())
     .pipe(gulpJshint.reporter(jshintStylish))
-    .pipe(gulpUglify({
-      compress: { 'negate_iife': false }
-    }))
+    .pipe(gulpUglify())
     .pipe(gulpConcat('bookmarklet.js'))
-    .pipe(map(function (file, cb) {
+    .pipe(map(function(file, cb) {
       file.contents = buffer.Buffer.concat([header, file.contents]);
       cb(null, file);
     }))
     .pipe(gulp.dest('dist/'));
 });
 
-gulp.task('clean', function () {
-  gulp.src('dist').pipe(gulpClean());
+gulp.task('clean', function() {
+  gulp.src('dist').pipe(rimraf());
 });
 
-gulp.task('default', function () {
-  gulp.run('clean', 'scripts');
-});
+gulp.task('default', ['clean', 'scripts']);
 
-gulp.task('watch', function () {
-  gulp.watch('app/{,*/}*.js', function () {
-    gulp.run('scripts');
-  });
+gulp.task('watch', function() {
+  gulp.watch('app/{,*/}*.js', ['scripts']);
 });


### PR DESCRIPTION
- remove deprecated `gulp.run`
- replaced gulp-clean with gulp-rimraf
- updated readme
