### PR TITLE
fix template gulpfile in order to generate valid bookmarklet. 

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -10,7 +10,8 @@
     "gulp-uglify": "^1.0.0",
     "gulp-util": "^3.0.0",
     "jshint-stylish": "^0.1.4",
-    "map-stream": "^0.1.0"
+    "map-stream": "^0.1.0",
+    "gulp-replace": "^0.5.3"    
   },
   "engines": {
     "node": ">=0.10.0"

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -8,12 +8,13 @@ var buffer = require('buffer'),
     gulpJshint = require('gulp-jshint'),
     gulpUglify = require('gulp-uglify'),
     jshintStylish = require('jshint-stylish'),
-    map = require('map-stream');
+    map = require('map-stream'),
+    replace = require('gulp-replace');    
 
 gulp.task('scripts', function () {
   var header = new Buffer('// Copy this to your URL bar:\njavascript:');
 
-  gulp.src('app/{,*/}*.js')
+  return gulp.src('app/{,*/}*.js')
     .pipe(gulpJshint())
     .pipe(gulpJshint.reporter(jshintStylish))
     .pipe(gulpUglify())
@@ -22,12 +23,19 @@ gulp.task('scripts', function () {
       file.contents = buffer.Buffer.concat([header, file.contents]);
       cb(null, file);
     }))
-    .pipe(gulp.dest('dist'));
+    .pipe(gulp.dest('build'));
+});
+
+gulp.task('postprocess', ['scripts'], function () {
+    return gulp.src('build/bookmarklet.js')
+        .pipe(replace(/!/, '('))
+        .pipe(replace(/\(\);$/g, ')();'))
+        .pipe(gulp.dest('dist'));;
 });
 
 gulp.task('clean', del.bind(null, 'dist'));
 
-gulp.task('default', ['clean', 'scripts']);
+gulp.task('default', ['clean', 'scripts', 'postprocess']);
 
 gulp.task('watch', function () {
   gulp.watch('app/{,*/}*.js', ['scripts']);


### PR DESCRIPTION
There was a problem: after clicking the bookmarklet, it is executed and afterwards the browser redirects to a blank page with "true" written on it. Refer to https://github.com/passy/generator-bookmarklet/issues/5

Tested on Firefox Windows 37.01